### PR TITLE
Allow user to favor non-native implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,12 @@ In node, attempts to use the following will be made.
 * [bluebird](https://www.npmjs.org/package/bluebird)
 * [q](https://www.npmjs.org/package/q) (`Promise` then `promise`)
 
+## Preferring user implementation over native
+
+Default behavior is to always favor native implementation if found. You can still favor the implementation of your choice without overriding global `Promise`:
+
+```js
+require('i-promise/config').use(MyPromiseImplementation);
+```
+
+You must run this code **before** any call to `require('i-promise')`.

--- a/config.js
+++ b/config.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var userPromise = null;
+
+//obscure to avoid browserify
+function grequire(moduleName) {
+  return require(moduleName);
+}
+
+// Registers a favorite implementation: get will return that value
+exports.use = function setPromise(Promise) {
+  userPromise = Promise;
+};
+
+// Window, global -> PromiseImpl
+exports.get = function getPromise(w, g) {
+  if (userPromise) return userPromise;
+
+  if (w && w.Promise) return w.Promise;
+  if (g && g.Promise) return g.Promise;
+
+  //browser window
+  if (w && w.document && w.navigator) {
+    //if Q is available, use it
+    if (w.Q && w.Q.Promise) return w.Q.Promise;
+    if (w.Q && w.Q.promise) return w.Q.promise;
+
+    return null;
+  }
+
+  // use _global.require so browserify doesn't attempt to load these
+  try { return grequire('es6-promise').Promise; } catch(err) {}
+  try { return grequire('es6-promises'); } catch(err) {}
+  try { return grequire('bluebird'); } catch(err) {}
+  try {
+    //wrap Q
+    var q = grequire('q');
+    if (q.Promise) return q.Promise; //latest
+    if (q.promise) return q.promise; //older
+  } catch(err) {}
+
+  return null;
+};

--- a/index.js
+++ b/index.js
@@ -1,34 +1,7 @@
 'use strict';
 
-//obscure to avoid browserify
-function grequire(moduleName) {
-  return require(moduleName);
-}
-
 //get the promise implementation, if available
-module.exports = (function getPromise(w, g) {
-  if (w && w.Promise) return w.Promise;
-  if (g && g.Promise) return g.Promise;
-  
-  //browser window
-  if (w && w.document && w.navigator) {
-    //if Q is available, use it
-    if (w.Q && w.Q.Promise) return w.Q.Promise;
-    if (w.Q && w.Q.promise) return w.Q.promise;
-    
-    return null;  
-  }
-  
-  // use _global.require so browserify doesn't attempt to load these
-  try { return grequire('es6-promise').Promise; } catch(err) {}
-  try { return grequire('es6-promises'); } catch(err) {}
-  try { return grequire('bluebird'); } catch(err) {}
-  try { 
-    //wrap Q
-    var q = grequire('q');
-    if (q.Promise) return q.Promise; //latest
-    if (q.promise) return q.promise; //older
-  } catch(err) {}
-  
-  return null;
-}(this.window, typeof global !== undefined && global || this));
+module.exports = require('./config').get(
+  this.window, // browser
+  typeof global !== undefined && global || this // node
+);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i-promise",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Returns an available ES6 Promise implementation, browserify friendly.",
   "main": "index.js",
   "dependencies": {},


### PR DESCRIPTION
Separating logic into a submodule `config` and the main one, we can still propose a "configuration phase" to final user without breaking API compatibility.

<!---
@huboard:{"order":0.5,"milestone_order":2,"custom_state":""}
-->
